### PR TITLE
Update exercise copy link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ GitHub Copilot CLI is a standalone terminal application with exciting features:
 
 Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
-[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=create-applications-with-the-copilot-CLI&owner=%40me&name=skills-copilot-cli-calculator&description=Exercise:+Copilot+CLI+Create+applications&visibility=public)
+[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=create-applications-with-the-copilot-CLI&owner=%40me&name=skills-create-applications-with-the-copilot-CLI&description=Exercise:+Copilot+CLI+Create+applications&visibility=public)
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>


### PR DESCRIPTION
This pull request makes a minor update to the exercise copy link in the `README.md` file to ensure the correct repository name is used when users create a new exercise.