### PR TITLE
Update test instructions for calculator operations

### DIFF
--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -110,7 +110,7 @@ As you add features, Copilot CLI can help you:
    > Add tests for the new calculator operations: 
    > - Expand tests based on the following example:
    >   - @images/calc-extended-operations.png
-   > - Add these tests to the existing src/tests/calculator.tests.js file
+   > - Add new tests for the new operations to the existing src/tests/calculator.tests.js file
    > - Use a popular Node.js testing framework if one isn't installed
    > - Make sure to include edge case tests like square root of negative numbers
    > - Make sure all tests run and pass


### PR DESCRIPTION
This pull request makes a minor clarification to the instructions for adding tests to the calculator application. The update specifies that new tests for the additional operations should be added to the existing `src/tests/calculator.tests.js` file. 