### PR TITLE
fix: accept both calculator.test.js and calculator.tests.js in Step 3 workflow

### DIFF
--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -128,7 +128,7 @@ Use the `!` command in Copilot CLI to execute shell commands directly from your 
    > Create comprehensive unit tests for all the calculator functions:
    > - Expand tests based on the following example:
    >   - @images/calc-basic-operations.png
-   > - Add these tests to a src/tests/calculator.tests.js file
+   > - Add these tests to a src/tests/calculator.test.js file
    > - Use a popular Node.js testing framework if one isn't installed
    > - addition, subtraction, multiplication, and division
    > - test edge cases like division by zero

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -112,7 +112,7 @@ As you add features, Copilot CLI can help you:
    > Add tests for the new calculator operations: 
    > - Expand tests based on the following example:
    >   - @images/calc-extended-operations.png
-   > - Add new tests for the new operations to the existing src/tests/calculator.tests.js file
+   > - Add new tests for the new operations to the existing src/tests/calculator.test.js file
    > - Use a popular Node.js testing framework if one isn't installed
    > - Make sure to include edge case tests like square root of negative numbers
    > - Make sure all tests run and pass

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -57,28 +57,40 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      - name: Check if calculator.tests.js has a modulo test
+      - name: Detect calculator test file
+        id: detect-test-file
+        run: |
+          if [ -f "src/tests/calculator.test.js" ]; then
+            echo "path=src/tests/calculator.test.js" >> "$GITHUB_OUTPUT"
+          elif [ -f "src/tests/calculator.tests.js" ]; then
+            echo "path=src/tests/calculator.tests.js" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Expected src/tests/calculator.test.js or src/tests/calculator.tests.js but neither was found"
+            exit 1
+          fi
+
+      - name: Check if calculator test file has a modulo test
         id: check-modulo-test
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v1
         with:
-          text-file: src/tests/calculator.tests.js
+          text-file: ${{ steps.detect-test-file.outputs.path }}
           keyphrase: modulo
 
-      - name: Check if calculator.tests.js has a power test
+      - name: Check if calculator test file has a power test
         id: check-power-test
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v1
         with:
-          text-file: src/tests/calculator.tests.js
+          text-file: ${{ steps.detect-test-file.outputs.path }}
           keyphrase: power
 
-      - name: Check if calculator.tests.js has a 'square root' test
+      - name: Check if calculator test file has a 'square root' test
         id: check-sqrt-test
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v1
         with:
-          text-file: src/tests/calculator.tests.js
+          text-file: ${{ steps.detect-test-file.outputs.path }}
           keyphrase: 'square'
 
       - name: Update comment - step results


### PR DESCRIPTION
## Summary

This PR fixes #32 by updating the Step 3 CI workflow to accept both `calculator.test.js` (standard Jest convention) and `calculator.tests.js` (non-standard) naming patterns.

## Problem

The Step 3 workflow hardcoded the test file path as `src/tests/calculator.tests.js`. When users follow standard Jest/Node.js conventions and create `calculator.test.js` (singular), the workflow fails with a "File does not exist" error even though all tests pass.

## Changes

### Workflow (`.github/workflows/3-step.yml`)
- Added a **detect-test-file** step that checks for either `calculator.test.js` or `calculator.tests.js` and outputs the discovered path
- All downstream keyphrase-checker steps now use the detected path instead of a hardcoded filename
- If neither file is found, a clear error message is shown

### Step docs (`.github/steps/2-step.md` and `3-step.md`)
- Updated the example prompts to reference `calculator.test.js` (standard Jest naming convention)

## Testing

The workflow will:
1. Prefer `calculator.test.js` if it exists
2. Fall back to `calculator.tests.js` if only that exists
3. Fail with a descriptive error if neither is found

Fixes #32