### PR TITLE
Fix markdown formatting and update subscription tiers

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -137,7 +137,7 @@ Issue templates help maintain consistency when team members create issues. This 
    > ```
 
 > [!NOTE]
-> After running `!gh auth login`, you will be provided with a link and an authentication code. Click the link to open GitHub in your browser, then enter the code to complete the authentication process.
+> After running `/login`, you will be provided with a link and an authentication code. Click the link to open GitHub in your browser, then enter the code to complete the authentication process.
 
 3. Explore useful slash commands in Copilot CLI:
    - View your current session information:

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -66,7 +66,7 @@ Issue templates help maintain consistency when team members create issues. This 
 
 > [!IMPORTANT]
 > If you have restarted your codespace you may need to run `copilot --allow-all` and then authenticate with GitHub again by running `!gh auth login` in your terminal,
-> or use `!gh auth login` from within the Copilot CLI session.
+> or use `/login` from within the Copilot CLI session.
 
 ### :keyboard: Activity 1: Getting to know your development environment
 
@@ -209,7 +209,7 @@ Issue templates help maintain consistency when team members create issues. This 
 - Make sure you have Node.js 22+ installed: `node --version`
 - If npm install fails, try: `sudo npm install -g @github/copilot`
 - Make sure you have GitHub Copilot access enabled for your account
-- If authentication fails, run `copilot` and run `!gh auth login`
+- If authentication fails, run `copilot` and run `/login`
 - You can also create the issue through the GitHub UI if needed
 
 </details>

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -26,7 +26,7 @@ GitHub Copilot CLI is a **standalone terminal application** that brings the powe
   - The session duration
   - The total lines of code edited
   - A breakdown of token usage per model
-- `/share [file|gist] [path]` - Share session to markdown file or GitHub gist
+- `/share [file|gist] [path]` - Share session to Markdown file or GitHub gist
 - Creating **custom agents** to encode specialized prompts and workflows
 - Delegating tasks to **Copilot coding agent** using the `/delegate` command
 
@@ -48,7 +48,7 @@ To install Copilot CLI, you need:
 
 - Node.js version 22 or later
 - npm version 10 or later
-- An active GitHub Copilot subscription (Pro, Pro+, Business, or Enterprise)
+- An active GitHub Copilot subscription (Free, Pro, Pro+, Business, or Enterprise)
 
 #### Issue Templates
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -40,7 +40,7 @@ When you have larger tasks, you can delegate them to Copilot coding agent:
 > - [About custom agents](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-custom-agents)
 
 > [!IMPORTANT]
-> If you have restarted your codespace you may need to run `copilot --allow-all --enable-all-github-mcp-tools` and then authenticate with GitHub again by running `!gh auth login` in the Copilot CLI.
+> If you have restarted your codespace you may need to run `copilot --allow-all --enable-all-github-mcp-tools` and then authenticate with GitHub again by running `/login` in the Copilot CLI.
 
 ### ⌨️ Activity: Create a New Branch for the Calculator App
 

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -49,7 +49,7 @@ As you add features, Copilot CLI can help you:
 - Save and share your development sessions using `/share`
 
 > [!IMPORTANT]
-> If you have restarted your codespace you may need to run `copilot --allow-all --enable-all-github-mcp-tools` and then authenticate with GitHub again by running `!gh auth login` from within the Copilot CLI session.
+> If you have restarted your codespace you may need to run `copilot --allow-all --enable-all-github-mcp-tools` and then authenticate with GitHub again by running `/login` from within the Copilot CLI session.
 
 > [!NOTE]
 > The `--allow-all` option in the Copilot CLI enables all permissions at once:

--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -46,7 +46,7 @@ The Copilot CLI enables you to:
 
 > [!IMPORTANT]
 > If you have restarted your codespace you may need to run `copilot --allow-all` and then authenticate with GitHub again by running `!gh auth login` in your terminal,
-> or use `!gh auth login` from within the Copilot CLI session.
+> or use `/login` from within the Copilot CLI session.
 
 ### ⌨️ Activity: Complete Your Pull Request Workflow
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Learn to use GitHub Copilot CLI—a standalone terminal application—for issue
   - Familiarity with basic command line (CLI) operations
   - Basic knowledge of GitHub repositories
   - Node.js version 22 or later (for Copilot CLI installation)
-  - A GitHub Copilot subscription (Pro, Pro+, Business, or Enterprise)
+  - A GitHub Copilot subscription (Free, Pro, Pro+, Business, or Enterprise)
 
 - **How long**: This exercise takes less than 60 minutes to complete.
 


### PR DESCRIPTION
### Summary
Updated Markdown brand and added Free tier as an allowed GH Copilot subscription tier (I'd imagine is supported)
Also updated command across the instructions to use /login as following change from commit 565c46a1e8db572263b1401e6facac377f1d60c3

Closes: #45

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
